### PR TITLE
A minimal implementation of rearrange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ cabal.project.local
 cabal.project.local~
 .HTF/
 .ghc.environment.*
+stack.yaml.lock

--- a/.stylish-haskell.yaml
+++ b/.stylish-haskell.yaml
@@ -1,0 +1,357 @@
+# stylish-haskell configuration file
+# ==================================
+
+# The stylish-haskell tool is mainly configured by specifying steps. These steps
+# are a list, so they have an order, and one specific step may appear more than
+# once (if needed). Each file is processed by these steps in the given order.
+steps:
+  # Convert some ASCII sequences to their Unicode equivalents. This is disabled
+  # by default.
+  # - unicode_syntax:
+  #     # In order to make this work, we also need to insert the UnicodeSyntax
+  #     # language pragma. If this flag is set to true, we insert it when it's
+  #     # not already present. You may want to disable it if you configure
+  #     # language extensions using some other method than pragmas. Default:
+  #     # true.
+  #     add_language_pragma: true
+
+  # Format module header
+  #
+  # Currently, this option is not configurable and will format all exports and
+  # module declarations to minimize diffs
+  #
+  # - module_header:
+  #     # How many spaces use for indentation in the module header.
+  #     indent: 4
+  #
+  #     # Should export lists be sorted?  Sorting is only performed within the
+  #     # export section, as delineated by Haddock comments.
+  #     sort: true
+  #
+  #     # See `separate_lists` for the `imports` step.
+  #     separate_lists: true
+
+  # Format record definitions. This is disabled by default.
+  #
+  # You can control the layout of record fields. The only rules that can't be configured
+  # are these:
+  #
+  # - "|" is always aligned with "="
+  # - "," in fields is always aligned with "{"
+  # - "}" is likewise always aligned with "{"
+  #
+  # - records:
+  #     # How to format equals sign between type constructor and data constructor.
+  #     # Possible values:
+  #     # - "same_line" -- leave "=" AND data constructor on the same line as the type constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the next line.
+  #     equals: "indent 2"
+  #
+  #     # How to format first field of each record constructor.
+  #     # Possible values:
+  #     # - "same_line" -- "{" and first field goes on the same line as the data constructor.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of the data constructor
+  #     first_field: "indent 2"
+  #
+  #     # How many spaces to insert between the column with "," and the beginning of the comment in the next line.
+  #     field_comment: 2
+  #
+  #     # How many spaces to insert before "deriving" clause. Deriving clauses are always on separate lines.
+  #     deriving: 2
+  #
+  #     # How many spaces to insert before "via" clause counted from indentation of deriving clause
+  #     # Possible values:
+  #     # - "same_line" -- "via" part goes on the same line as "deriving" keyword.
+  #     # - "indent N" -- insert a new line and N spaces from the beginning of "deriving" keyword.
+  #     via: "indent 2"
+  #
+  #     # Sort typeclass names in the "deriving" list alphabetically.
+  #     sort_deriving: true
+  #
+  #     # Wheter or not to break enums onto several lines
+  #     #
+  #     # Default: false
+  #     break_enums: false
+  #
+  #     # Whether or not to break single constructor data types before `=` sign
+  #     #
+  #     # Default: true
+  #     break_single_constructors: true
+  #
+  #     # Whether or not to curry constraints on function.
+  #     #
+  #     # E.g: @allValues :: Enum a => Bounded a => Proxy a -> [a]@
+  #     #
+  #     # Instead of @allValues :: (Enum a, Bounded a) => Proxy a -> [a]@
+  #     #
+  #     # Default: false
+  #     curried_context: false
+
+  # Align the right hand side of some elements.  This is quite conservative
+  # and only applies to statements where each element occupies a single
+  # line.
+  # Possible values:
+  # - always - Always align statements.
+  # - adjacent - Align statements that are on adjacent lines in groups.
+  # - never - Never align statements.
+  # All default to always.
+  - simple_align:
+      cases: always
+      top_level_patterns: always
+      records: always
+      multi_way_if: always
+
+  # Import cleanup
+  - imports:
+      # There are different ways we can align names and lists.
+      #
+      # - global: Align the import names and import list throughout the entire
+      #   file.
+      #
+      # - file: Like global, but don't add padding when there are no qualified
+      #   imports in the file.
+      #
+      # - group: Only align the imports per group (a group is formed by adjacent
+      #   import lines).
+      #
+      # - none: Do not perform any alignment.
+      #
+      # Default: global.
+      align: global
+
+      # The following options affect only import list alignment.
+      #
+      # List align has following options:
+      #
+      # - after_alias: Import list is aligned with end of import including
+      #   'as' and 'hiding' keywords.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                          init, last, length)
+      #
+      # - with_alias: Import list is aligned with start of alias or hiding.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #   >                                 init, last, length)
+      #
+      # - with_module_name: Import list is aligned `list_padding` spaces after
+      #   the module name.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head,
+      #                          init, last, length)
+      #
+      #   This is mainly intended for use with `pad_module_names: false`.
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, head,
+      #                          init, last, length, scanl, scanr, take, drop,
+      #                          sort, nub)
+      #
+      # - new_line: Import list starts always on new line.
+      #
+      #   > import qualified Data.List      as List
+      #   >     (concat, foldl, foldr, head, init, last, length)
+      #
+      # - repeat: Repeat the module name to align the import list.
+      #
+      #   > import qualified Data.List      as List (concat, foldl, foldr, head)
+      #   > import qualified Data.List      as List (init, last, length)
+      #
+      # Default: after_alias
+      list_align: after_alias
+
+      # Right-pad the module names to align imports in a group:
+      #
+      # - true: a little more readable
+      #
+      #   > import qualified Data.List       as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # - false: diff-safe
+      #
+      #   > import qualified Data.List as List (concat, foldl, foldr, init,
+      #   >                                     last, length)
+      #   > import qualified Data.List.Extra as List (concat, foldl, foldr,
+      #   >                                           init, last, length)
+      #
+      # Default: true
+      pad_module_names: true
+
+      # Long list align style takes effect when import is too long. This is
+      # determined by 'columns' setting.
+      #
+      # - inline: This option will put as much specs on same line as possible.
+      #
+      # - new_line: Import list will start on new line.
+      #
+      # - new_line_multiline: Import list will start on new line when it's
+      #   short enough to fit to single line. Otherwise it'll be multiline.
+      #
+      # - multiline: One line per import list entry.
+      #   Type with constructor list acts like single import.
+      #
+      #   > import qualified Data.Map as M
+      #   >     ( empty
+      #   >     , singleton
+      #   >     , ...
+      #   >     , delete
+      #   >     )
+      #
+      # Default: inline
+      long_list_align: inline
+
+      # Align empty list (importing instances)
+      #
+      # Empty list align has following options
+      #
+      # - inherit: inherit list_align setting
+      #
+      # - right_after: () is right after the module name:
+      #
+      #   > import Vector.Instances ()
+      #
+      # Default: inherit
+      empty_list_align: inherit
+
+      # List padding determines indentation of import list on lines after import.
+      # This option affects 'long_list_align'.
+      #
+      # - <integer>: constant value
+      #
+      # - module_name: align under start of module name.
+      #   Useful for 'file' and 'group' align settings.
+      #
+      # Default: 4
+      list_padding: 4
+
+      # Separate lists option affects formatting of import list for type
+      # or class. The only difference is single space between type and list
+      # of constructors, selectors and class functions.
+      #
+      # - true: There is single space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable (fold, foldl, foldMap))
+      #
+      # - false: There is no space between Foldable type and list of it's
+      #   functions.
+      #
+      #   > import Data.Foldable (Foldable(fold, foldl, foldMap))
+      #
+      # Default: true
+      separate_lists: true
+
+      # Space surround option affects formatting of import lists on a single
+      # line. The only difference is single space after the initial
+      # parenthesis and a single space before the terminal parenthesis.
+      #
+      # - true: There is single space associated with the enclosing
+      #   parenthesis.
+      #
+      #   > import Data.Foo ( foo )
+      #
+      # - false: There is no space associated with the enclosing parenthesis
+      #
+      #   > import Data.Foo (foo)
+      #
+      # Default: false
+      space_surround: false
+
+      # Enabling this argument will use the new GHC lib parse to format imports.
+      #
+      # This currently assumes a few things, it will assume that you want post
+      # qualified imports. It is also not as feature complete as the old
+      # imports formatting.
+      #
+      # It does not remove redundant lines or merge lines. As such, the full
+      # feature scope is still pending.
+      #
+      # It _is_ however, a fine alternative if you are using features that are
+      # not parseable by haskell src extensions and you're comfortable with the
+      # presets.
+      #
+      # Default: false
+      ghc_lib_parser: false
+
+  # Language pragmas
+  - language_pragmas:
+      # We can generate different styles of language pragma lists.
+      #
+      # - vertical: Vertical-spaced language pragmas, one per line.
+      #
+      # - compact: A more compact style.
+      #
+      # - compact_line: Similar to compact, but wrap each line with
+      #   `{-#LANGUAGE #-}'.
+      #
+      # Default: vertical.
+      style: vertical
+
+      # Align affects alignment of closing pragma brackets.
+      #
+      # - true: Brackets are aligned in same column.
+      #
+      # - false: Brackets are not aligned together. There is only one space
+      #   between actual import and closing bracket.
+      #
+      # Default: true
+      align: true
+
+      # stylish-haskell can detect redundancy of some language pragmas. If this
+      # is set to true, it will remove those redundant pragmas. Default: true.
+      remove_redundant: true
+
+      # Language prefix to be used for pragma declaration, this allows you to
+      # use other options non case-sensitive like "language" or "Language".
+      # If a non correct String is provided, it will default to: LANGUAGE.
+      language_prefix: LANGUAGE
+
+  # Replace tabs by spaces. This is disabled by default.
+  # - tabs:
+  #     # Number of spaces to use for each tab. Default: 8, as specified by the
+  #     # Haskell report.
+  #     spaces: 8
+
+  # Remove trailing whitespace
+  - trailing_whitespace: {}
+
+  # Squash multiple spaces between the left and right hand sides of some
+  # elements into single spaces. Basically, this undoes the effect of
+  # simple_align but is a bit less conservative.
+  # - squash: {}
+
+# A common setting is the number of columns (parts of) code will be wrapped
+# to. Different steps take this into account.
+#
+# Set this to null to disable all line wrapping.
+#
+# Default: 80.
+columns: 80
+
+# By default, line endings are converted according to the OS. You can override
+# preferred format here.
+#
+# - native: Native newline format. CRLF on Windows, LF on other OSes.
+#
+# - lf: Convert to LF ("\n").
+#
+# - crlf: Convert to CRLF ("\r\n").
+#
+# Default: native.
+newline: native
+
+# Sometimes, language extensions are specified in a cabal file or from the
+# command line instead of using language pragmas in the file. stylish-haskell
+# needs to be aware of these, so it can parse the file correctly.
+#
+# No language extensions are enabled by default.
+# language_extensions:
+  # - TemplateHaskell
+  # - QuasiQuotes
+
+# Attempt to find the cabal file in ancestors of the current directory, and
+# parse options (currently only language extensions) from that.
+#
+# Default: true
+cabal: true

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # fei-einops
+This package mimics the idea in [Einops](https://github.com/arogozhnikov/einops) library
+
+For example:
+- `rearrange t "h w c -> c h w" []` will transpose the tensor from HWC to CHW.
+- `rearrange t "b n c -> b (n c) []"` will reshape the tensor by merging up the last 2 axes.
+- `rearrange t "(b n) c -> b n c" [#b .== 2]` will reshape the tensor by decompose the 1st axis into 2, where the new axis `n` is calculated automatically.
+- ...
+
+In most cases, the tensor can be `SymbolHandle`, `NDArrayHandle`, `NDArray` for mxnet.

--- a/fei-einops.cabal
+++ b/fei-einops.cabal
@@ -22,13 +22,18 @@ library
   build-depends:       base >= 4.7 && < 5,
                        lens < 5,
                        rio < 0.2,
+                       mtl < 3,
                        attoparsec < 0.14,
-                       containers < 0.7
+                       containers < 0.7,
+                       mfsolve
   if flag(mxnet) {
-      build-depends:   fei-base
+      build-depends:   fei-base, fei-nn
+      cpp-options:     -DMXNET
+      other-modules:   Fei.Einops.MXNet
   }
   hs-source-dirs:      src
-  exposed-modules:     
+  exposed-modules:     Fei.Einops.Operation,
+                       Fei.Einops
   other-modules:       Fei.Einops.Expression
   default-language:    Haskell2010
   default-extensions:  FlexibleContexts,

--- a/fei-einops.cabal
+++ b/fei-einops.cabal
@@ -1,0 +1,53 @@
+cabal-version:       2.4
+name:                fei-einops
+version:             0.0.1
+synopsis:            Tensor operations
+description:         This library mimics the feature of python library einops.
+homepage:
+license:             BSD-3-Clause
+license-file:        LICENSE
+author:              Jiasen Wu
+maintainer:          jiasenwu@hotmail.com
+copyright:           2021 - Jiasen Wu
+category:            Machine Learning, AI
+build-type:          Simple
+extra-source-files:  README.md
+
+Flag mxnet {
+  Description: MXNet backend
+  Default: False
+}
+
+library
+  build-depends:       base >= 4.7 && < 5,
+                       lens < 5,
+                       rio < 0.2,
+                       attoparsec < 0.14,
+                       containers < 0.7
+  if flag(mxnet) {
+      build-depends:   fei-base
+  }
+  hs-source-dirs:      src
+  exposed-modules:     
+  other-modules:       Fei.Einops.Expression
+  default-language:    Haskell2010
+  default-extensions:  FlexibleContexts,
+                       GADTs,
+                       StandaloneDeriving,
+                       DeriveGeneric,
+                       GeneralizedNewtypeDeriving,
+                       ExplicitForAll,
+                       DataKinds,
+                       TypeFamilies,
+                       OverloadedLabels,
+                       OverloadedStrings,
+                       LambdaCase,
+                       MultiWayIf,
+                       DoAndIfThenElse,
+                       NoImplicitPrelude,
+                       TupleSections,
+                       ScopedTypeVariables
+
+source-repository head
+  type:     git
+  location: https://github.com/pierric/fei-einops

--- a/fei-einops.cabal
+++ b/fei-einops.cabal
@@ -27,7 +27,7 @@ library
                        containers < 0.7,
                        mfsolve
   if flag(mxnet) {
-      build-depends:   fei-base, fei-nn
+      build-depends:   fei-base >= 1.1.0, fei-nn >= 2.0.0
       cpp-options:     -DMXNET
       other-modules:   Fei.Einops.MXNet
   }

--- a/src/Fei/Einops.hs
+++ b/src/Fei/Einops.hs
@@ -1,0 +1,12 @@
+{-# LANGUAGE CPP #-}
+module Fei.Einops(
+    module Fei.Einops.Operation,
+#ifdef MXNET
+    module Fei.Einops.MXNet
+#endif
+    ) where
+
+import           Fei.Einops.Operation
+#ifdef MXNET
+import           Fei.Einops.MXNet
+#endif

--- a/src/Fei/Einops/Expression.hs
+++ b/src/Fei/Einops/Expression.hs
@@ -1,0 +1,61 @@
+module Fei.Einops.Expression where
+
+import           Control.Lens         (_Left, (%~))
+import qualified Data.Attoparsec.Text as P
+import qualified Data.Set             as Set
+import           RIO                  hiding ((%~))
+import qualified RIO.Text             as T
+
+newtype Var = Var Text
+    deriving (Eq, Ord, Show)
+data Term = Unit | Sing Var | Ellipse [Var]
+newtype Head = Head [Term]
+data Expr = Expr Head Head
+
+data Mode = ModeRearrange
+
+data Error = DuplicatedVars Head
+           | DifferentVars [Var] [Var]
+           | ParsingError String
+
+variables :: Head -> [Var]
+variables (Head ts) =
+    let vars Unit         = []
+        vars (Sing v)     = [v]
+        vars (Ellipse vs) = vs
+     in concatMap vars ts
+
+_check :: Mode -> Expr -> Either Error Expr
+_check ModeRearrange expr@(Expr left right)
+
+  | set_lv /= set_rv = Left $ DifferentVars lv rv
+  | length set_lv /= Set.size set_lv = Left $ DuplicatedVars left
+  | length set_rv /= Set.size set_rv = Left $ DuplicatedVars right
+  | otherwise = Right expr
+
+    where
+        lv = variables left
+        rv = variables right
+        set_lv = Set.fromList lv
+        set_rv = Set.fromList rv
+
+parse :: Text -> Either Error Expr
+parse text = P.parseOnly expr text & _Left %~ ParsingError >>= _check ModeRearrange
+    where
+        unit = const Unit <$> (P.string "()" <|> P.string "1")
+        var  = do
+            str <- liftA2 (:) P.letter (P.many' $ P.letter <|> P.digit)
+            return $ Var $ T.pack str
+        ellipse = do
+            P.char '('
+            vs <- P.sepBy1' var P.skipSpace
+            P.char ')'
+            return $ Ellipse vs
+        head = P.sepBy1' (unit <|> (Sing <$> var) <|> ellipse) P.skipSpace
+        expr = do
+            h1 <- head
+            P.skipSpace
+            P.string "->"
+            P.skipSpace
+            h2 <- head
+            return $ Expr (Head h1) (Head h2)

--- a/src/Fei/Einops/Expression.hs
+++ b/src/Fei/Einops/Expression.hs
@@ -1,57 +1,68 @@
+{-# LANGUAGE DeriveFunctor #-}
 module Fei.Einops.Expression where
 
-import           Control.Lens         (_Left, (%~))
+import           Control.Lens         (_1, _2, _Left, ix, (%~), (^?!))
+import           Control.Monad.Except (throwError)
 import qualified Data.Attoparsec.Text as P
 import qualified Data.Set             as Set
+import qualified Math.MFSolve         as Solver
 import           RIO                  hiding ((%~))
+import qualified RIO.HashMap          as M
 import qualified RIO.Text             as T
 
-newtype Var = Var Text
-    deriving (Eq, Ord, Show)
-data Term = Unit | Sing Var | Ellipse [Var]
-newtype Head = Head [Term]
-data Expr = Expr Head Head
+newtype Axis = Axis Text
+    deriving (Eq, Ord, Show, Generic, Hashable)
+data Term a = Sing a | Ellipse [a]
+    deriving (Show, Functor)
+newtype Head a = Head [Term a]
+    deriving (Show, Functor)
+data Expr = Expr (Head Axis) (Head Axis)
+    deriving (Show)
 
 data Mode = ModeRearrange
 
-data Error = DuplicatedVars Head
-           | DifferentVars [Var] [Var]
+data Error = DuplicatedAxes (Head Axis)
+           | DifferentAxes [Axis] [Axis]
            | ParsingError String
+           | InvalidAxis [Axis]
+           | Unsolvable (Solver.DepError Axis Float)
+           | UnresolvedDim [Axis]
+    deriving (Show)
 
-variables :: Head -> [Var]
-variables (Head ts) =
-    let vars Unit         = []
-        vars (Sing v)     = [v]
+instance Exception Error
+
+axes :: Head a -> [a]
+axes (Head ts) =
+    let vars (Sing v)     = [v]
         vars (Ellipse vs) = vs
      in concatMap vars ts
 
 _check :: Mode -> Expr -> Either Error Expr
 _check ModeRearrange expr@(Expr left right)
 
-  | set_lv /= set_rv = Left $ DifferentVars lv rv
-  | length set_lv /= Set.size set_lv = Left $ DuplicatedVars left
-  | length set_rv /= Set.size set_rv = Left $ DuplicatedVars right
+  | set_lv /= set_rv = Left $ DifferentAxes lv rv
+  | length set_lv /= Set.size set_lv = Left $ DuplicatedAxes left
+  | length set_rv /= Set.size set_rv = Left $ DuplicatedAxes right
   | otherwise = Right expr
 
     where
-        lv = variables left
-        rv = variables right
+        lv     = axes left
+        rv     = axes right
         set_lv = Set.fromList lv
         set_rv = Set.fromList rv
 
 parse :: Text -> Either Error Expr
 parse text = P.parseOnly expr text & _Left %~ ParsingError >>= _check ModeRearrange
     where
-        unit = const Unit <$> (P.string "()" <|> P.string "1")
         var  = do
             str <- liftA2 (:) P.letter (P.many' $ P.letter <|> P.digit)
-            return $ Var $ T.pack str
+            return $ Axis $ T.pack str
         ellipse = do
             P.char '('
             vs <- P.sepBy1' var P.skipSpace
             P.char ')'
             return $ Ellipse vs
-        head = P.sepBy1' (unit <|> (Sing <$> var) <|> ellipse) P.skipSpace
+        head = P.sepBy1' ((Sing <$> var) <|> ellipse) P.skipSpace
         expr = do
             h1 <- head
             P.skipSpace
@@ -59,3 +70,42 @@ parse text = P.parseOnly expr text & _Left %~ ParsingError >>= _check ModeRearra
             P.skipSpace
             h2 <- head
             return $ Expr (Head h1) (Head h2)
+
+expandHead :: Head Int -> [Int]
+expandHead = axes
+
+reduceHead :: Num a => Head a -> [a]
+reduceHead (Head ts) = map each ts
+    where
+        each (Sing a)     = a
+        each (Ellipse as) = product as
+
+makeVariables :: Expr -> HashMap Axis (Solver.Expr Axis Float)
+makeVariables (Expr left right) = foldl' add M.empty all_axes
+    where
+        left_axes  = axes left
+        right_axes = axes right
+        all_axes   = left_axes ++ right_axes
+        add m a = M.insertWith (flip const) a (Solver.makeVariable a) m
+
+solve :: Expr -> [Int] -> [(Axis, Int)] -> Either Error [Head Int]
+solve expr@(Expr left right) input knowns = do
+    _check ModeRearrange expr
+    let vars   = makeVariables expr
+        wrong_kn = M.difference (M.fromList knowns) vars
+    when (not $ M.null wrong_kn) $
+        throwError $ InvalidAxis $ M.keys wrong_kn
+
+    let leftEs  = (vars ^?!) . ix <$> left
+        knEs   = map (_1 %~ (\k -> vars ^?! ix k)) knowns
+        eq (e, i) = e Solver.=== (Solver.makeConstant $ fromIntegral i)
+    solution <- _Left %~ Unsolvable $ flip Solver.execSolver Solver.noDeps $ do
+        mapM_ eq $ zip (reduceHead leftEs) input
+        mapM_ eq knEs
+    let kwn    = M.fromList $ map (_2 %~ floor) $ Solver.knownVars solution
+        leftS  = (kwn ^?!) . ix <$> left
+        rightS = (kwn ^?!) . ix <$> right
+        unkwn  = M.difference (() <$ vars) (() <$ kwn)
+    when (not $ M.null unkwn) $
+        throwError $ UnresolvedDim $ M.keys unkwn
+    return [leftS, rightS]

--- a/src/Fei/Einops/Expression.hs
+++ b/src/Fei/Einops/Expression.hs
@@ -31,6 +31,10 @@ data Error = DuplicatedAxes (Head Axis)
 
 instance Exception Error
 
+isEllipse :: Term a -> Bool
+isEllipse (Ellipse _) = True
+isEllipse _           = False
+
 axes :: Head a -> [a]
 axes (Head ts) =
     let vars (Sing v)     = [v]

--- a/src/Fei/Einops/MXNet.hs
+++ b/src/Fei/Einops/MXNet.hs
@@ -1,0 +1,15 @@
+{-# LANGUAGE FlexibleInstances    #-}
+{-# LANGUAGE UndecidableInstances #-}
+module Fei.Einops.MXNet where
+
+import           MXNet.Base.Tensor
+import           MXNet.NN.Layer       (reshape, transpose)
+import           RIO
+
+import           Fei.Einops.Operation
+
+instance (MonadIO (TensorMonad t), MonadThrow (TensorMonad t), PrimTensorOp t t) => TensorType t where
+    type ExecutionMonad t = TensorMonad t
+    tensorReshape  = reshape
+    tensorTranpose = flip transpose
+

--- a/src/Fei/Einops/MXNet.hs
+++ b/src/Fei/Einops/MXNet.hs
@@ -2,14 +2,126 @@
 {-# LANGUAGE UndecidableInstances #-}
 module Fei.Einops.MXNet where
 
+import           Control.Lens          (ix, (^?))
+import           Data.Monoid           (Sum (..))
+import           MXNet.Base            (DType, NDArray (..), Symbol,
+                                        SymbolHandle, ndshape)
 import           MXNet.Base.Tensor
-import           MXNet.NN.Layer       (reshape, transpose)
-import           RIO
+import           MXNet.NN.Layer        (reshape, transpose)
+import           RIO                   hiding ((^?))
+import qualified RIO.HashMap           as M
+import qualified RIO.List              as L (groupBy)
+import qualified RIO.NonEmpty          as NE
 
+import           Fei.Einops.Expression
 import           Fei.Einops.Operation
 
-instance (MonadIO (TensorMonad t), MonadThrow (TensorMonad t), PrimTensorOp t t) => TensorType t where
+
+data ReshapeOp =
+      AxisKnown Int          -- a known axis
+    | AxisCopy               -- copy the axis: (0,)
+    | AxisSplitL Int         -- split into 2 with a known left:  (-4, n, -1)
+    | AxisSplitR Int         -- split into 2 with a known right: (-4, -1, n)
+    | AxisSplitM [Int]       -- split into a list of known axes: (n, m, l, ..)
+    | AxisSplitU [Int] [Int] -- split into at most one unknown axis
+    | AxisMerge              -- merge 2 axes: (-3,)
+
+termsToOps :: ReshapeDirection -> HashMap Axis Int -> [Term Axis] -> Maybe [ReshapeOp]
+termsToOps dir knowns terms = mapM each terms
+    where
+        each (Sing a) = pure $ case knowns ^? ix a of
+                          Nothing -> AxisCopy
+                          Just v  -> AxisKnown v
+        each (Ellipse as) = let vs  = map ((knowns ^?) . ix) as
+                             in case dir of
+                                  ReshapeExpand -> expand vs
+                                  ReshapeReduce -> reduce vs
+        expand vs =
+            let num = length vs
+                seg = L.groupBy (\a b -> isJust a && isJust b) vs
+             in case () of
+                  _ | num > 2 ->
+                      case seg of
+                         [js] -> pure $ AxisSplitM (chopJust js)
+                         [[Nothing], js] -> pure $ AxisSplitU [] (chopJust js)
+                         [js, [Nothing]] -> pure $ AxisSplitU (chopJust js) []
+                         [js1, [Nothing], js2] -> pure $ AxisSplitU (chopJust js1) (chopJust js2)
+                         _ -> Nothing
+                    | num == 2 ->
+                        case vs of
+                          [Nothing, Just v] -> pure $ AxisSplitR v
+                          [Just v, Nothing] -> pure $ AxisSplitL v
+                          [Just u, Just v]  -> pure $ AxisSplitM [u, v]
+                          _                 -> Nothing
+                  _ -> Nothing
+
+        reduce vs =
+            let num = length vs
+                seg = L.groupBy (\a b -> isJust a && isJust b) vs
+             in case () of
+                  _ | num == 2 -> pure $ AxisMerge
+                    | num > 2 && and (map isJust vs) -> pure $ AxisKnown $ product $ chopJust vs
+                  _ -> Nothing
+
+        chopJust js = [a | Just a <- js]
+
+opToCode :: ReshapeOp -> [Int]
+opToCode (AxisKnown v)      = [v]
+opToCode AxisCopy           = [0]
+opToCode (AxisSplitL v)     = [-4, v, -1]
+opToCode (AxisSplitR v)     = [-4, -1, v]
+opToCode (AxisSplitM vs)    = vs
+opToCode (AxisSplitU us vs) = us ++ [-1] ++ vs
+opToCode AxisMerge          = [-3]
+
+numSplitU :: [ReshapeOp] -> Int
+numSplitU = getSum . mconcat . map (Sum . isAxisSplitU)
+    where
+        isAxisSplitU (AxisSplitU _ _ ) = 1
+        isAxisSplitU _                 = 0
+
+data ReshapeSymError = CannotReshape [Term Axis] [(Axis, Int)]
+    deriving Show
+
+instance Exception ReshapeSymError
+
+class (MonadIO (TensorMonad t), MonadThrow (TensorMonad t), PrimTensorOp t t) => MXTensor t where
+    mxGetShape   :: t -> IO (Maybe [Int])
+    mxReshapeSym :: ReshapeDirection -> Head Axis -> [(Axis, Int)] -> t -> TensorMonad t t
+
+instance MXTensor SymbolHandle where
+    mxGetShape _ = return Nothing
+    mxReshapeSym dir (Head terms) knowns sym = do
+        -- given a head, say 'c (w h)', we shall reshape a symbol of shape [c, w*h] to
+        -- [c, w, h] (expand), or in the opposite direction (reduce). This is possible
+        -- with special values 0, -1, -2, -3, -4 in the reshape api, see
+        -- https://mxnet.apache.org/versions/1.7.0/api/python/docs/api/symbol/symbol.html#mxnet.symbol.reshape
+        --
+        -- But we will restrict the forms of head.
+        -- * expanding direction
+        --   * multiple ellipses, each of size 2, with at least one axis known
+        --   * otherwise, at most one axis unknown in all ellipses
+        --
+        -- * reducing direction
+        --   * ellipses of size 2, with either known/unknown axes
+        --   * ellipses of size > 2, with all known axes
+        --
+        case termsToOps dir (M.fromList knowns) terms of
+          Nothing -> throwM $ CannotReshape terms knowns
+          Just ops
+            | numSplitU ops > 1 -> throwM $ CannotReshape terms knowns
+            | otherwise -> do
+                let code = concatMap opToCode ops
+                reshape code sym
+
+instance DType a => MXTensor (NDArray a) where
+    mxGetShape t = ndshape t >>= return . Just . NE.toList
+    mxReshapeSym = error "No need to reshape a NDArray symolically."
+
+instance (MXTensor t, MonadIO (TensorMonad t), MonadThrow (TensorMonad t), PrimTensorOp t t) => TensorType t where
     type ExecutionMonad t = TensorMonad t
+    tensorGetShape = liftIO . mxGetShape
+    tensorReshapeSym = mxReshapeSym
     tensorReshape  = reshape
     tensorTranpose = flip transpose
 

--- a/src/Fei/Einops/MXNet.hs
+++ b/src/Fei/Einops/MXNet.hs
@@ -6,8 +6,9 @@ import           Control.Lens          (ix, (^?))
 import           Data.Monoid           (Sum (..))
 import           MXNet.Base            (DType, NDArray (..), Symbol,
                                         SymbolHandle, ndshape)
-import           MXNet.Base.Tensor
-import           MXNet.NN.Layer        (reshape, transpose)
+import           MXNet.Base.Tensor     (PrimTensorOp, TensorMonad, reshape,
+                                        transpose)
+import           MXNet.NN.Layer        ()
 import           RIO                   hiding ((^?))
 import qualified RIO.HashMap           as M
 import qualified RIO.List              as L (groupBy)

--- a/src/Fei/Einops/Operation.hs
+++ b/src/Fei/Einops/Operation.hs
@@ -1,0 +1,33 @@
+module Fei.Einops.Operation where
+
+import           Control.Lens          (_1, ix, (^?!))
+import           RIO
+import qualified RIO.HashMap           as M
+
+import           Fei.Einops.Expression
+
+class (MonadIO (ExecutionMonad t), MonadThrow (ExecutionMonad t)) => TensorType t where
+    type ExecutionMonad t :: * -> *
+
+    tensorReshape :: [Int] -> t -> ExecutionMonad t t
+    tensorTranpose :: [Int] -> t -> ExecutionMonad t t
+
+rearrange :: TensorType t => t -> [Int] -> Text -> [(Text, Int)] -> ExecutionMonad t t
+rearrange tensor shape expr dims =
+    case parse expr of
+      Left err -> throwM err
+      Right e@(Expr left right) -> do
+          let daxes = map (_1 %~ Axis) dims
+          case solve e shape daxes of
+            Left err -> throwM err
+            Right [h0, h1] -> do
+              let src_shape = expandHead h0
+                  dst_shape = reduceHead h1
+                  laxes     = axes left
+                  raxes     = axes right
+                  indices   = M.fromList $ zip laxes [0..]
+                  mapping   = map (\a -> indices ^?! ix a) raxes
+              tensor <- tensorReshape  src_shape tensor
+              tensor <- tensorTranpose mapping   tensor
+              tensor <- tensorReshape  dst_shape tensor
+              return tensor

--- a/src/Fei/Einops/Operation.hs
+++ b/src/Fei/Einops/Operation.hs
@@ -12,11 +12,15 @@ import qualified RIO.Text              as T
 
 import           Fei.Einops.Expression
 
+data ReshapeDirection = ReshapeExpand | ReshapeReduce
+
 class (MonadIO (ExecutionMonad t), MonadThrow (ExecutionMonad t)) => TensorType t where
     type ExecutionMonad t :: * -> *
 
-    tensorReshape :: [Int] -> t -> ExecutionMonad t t
-    tensorTranpose :: [Int] -> t -> ExecutionMonad t t
+    tensorGetShape   :: t -> ExecutionMonad t (Maybe [Int])
+    tensorReshape    :: [Int] -> t -> ExecutionMonad t t
+    tensorReshapeSym :: ReshapeDirection -> Head Axis -> [(Axis, Int)] -> t -> ExecutionMonad t t
+    tensorTranpose   :: [Int] -> t -> ExecutionMonad t t
 
 instance KnownSymbol x => IsLabel (x :: Symbol) Axis where
     fromLabel = Axis (T.pack $ symbolVal (Proxy :: Proxy x))
@@ -24,21 +28,33 @@ instance KnownSymbol x => IsLabel (x :: Symbol) Axis where
 (.==) :: Axis -> Int -> (Axis, Int)
 (.==) = (,)
 
-rearrange :: TensorType t => t -> [Int] -> Text -> [(Axis, Int)] -> ExecutionMonad t t
-rearrange tensor shape expr dims =
+rearrange :: TensorType t => t -> Text -> [(Axis, Int)] -> ExecutionMonad t t
+rearrange tensor expr dims =
     case parse expr of
       Left err -> throwM err
-      Right e@(Expr left right) ->
-          case solve e shape dims of
-            Left err -> throwM err
-            Right [h0, h1] -> do
-              let src_shape = expandHead h0
-                  dst_shape = reduceHead h1
-                  laxes     = axes left
-                  raxes     = axes right
-                  indices   = M.fromList $ zip laxes [0..]
-                  mapping   = map (\a -> indices ^?! ix a) raxes
-              tensor <- tensorReshape  src_shape tensor
-              tensor <- tensorTranpose mapping   tensor
-              tensor <- tensorReshape  dst_shape tensor
-              return tensor
+      Right e@(Expr left right) -> do
+          let laxes     = axes left
+              raxes     = axes right
+              indices   = M.fromList $ zip laxes [0..]
+              mapping   = map (\a -> indices ^?! ix a) raxes
+          mshp <- tensorGetShape tensor
+          case mshp of
+            -- restricted mode. We can infer symbolically the relationship
+            -- of axes, but it is not possible to accept the relationship by
+            -- the backend. So we resort everything to the backend side.
+            Nothing -> do
+                tensor <- tensorReshapeSym ReshapeExpand left dims tensor
+                tensor <- tensorTranpose mapping   tensor
+                tensor <- tensorReshapeSym ReshapeReduce right dims tensor
+                return tensor
+            -- we have the shape of tensor, and we can solve the equation
+            Just shape -> do
+                case solve e shape dims of
+                  Left err -> throwM err
+                  Right [h0, h1] -> do
+                      let src_shape = expandHead h0
+                          dst_shape = reduceHead h1
+                      tensor <- tensorReshape src_shape tensor
+                      tensor <- tensorTranpose mapping   tensor
+                      tensor <- tensorReshape  dst_shape tensor
+                      return tensor

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,17 @@
+resolver: lts-14.27
+packages:
+- .
+- ../fei-base/
+- ../tuple-ops
+extra-deps:
+- git: https://github.com/0xCM/type-combinators.git
+  commit: 58167dd4017b666ff592bb9493b0570a054aabdb
+extra-include-dirs:
+- /home/jiasen/workspace/mxnet/build-1.6.0/include
+extra-lib-dirs:
+- /home/jiasen/workspace/mxnet/build-1.6.0
+flags:
+  fei-base:
+    mxnet_geq_10600: true
+  fei-einops:
+    mxnet: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,17 +1,22 @@
-resolver: lts-14.27
+resolver: lts-17.2
 packages:
 - .
 - ../fei-base/
+- ../fei-nn/
 - ../tuple-ops
 extra-deps:
 - git: https://github.com/0xCM/type-combinators.git
   commit: 58167dd4017b666ff592bb9493b0570a054aabdb
+- git: https://github.com/pierric/haskell-src-exts.git
+  commit: 792ec73bc3b0e8d4aa2683af6b2a3fc03b5f8d95
 extra-include-dirs:
 - /home/jiasen/workspace/mxnet/build-1.6.0/include
 extra-lib-dirs:
 - /home/jiasen/workspace/mxnet/build-1.6.0
 flags:
   fei-base:
+    mxnet_geq_10600: true
+  fei-nn:
     mxnet_geq_10600: true
   fei-einops:
     mxnet: true

--- a/stack.yaml
+++ b/stack.yaml
@@ -10,13 +10,13 @@ extra-deps:
 - git: https://github.com/pierric/haskell-src-exts.git
   commit: 792ec73bc3b0e8d4aa2683af6b2a3fc03b5f8d95
 extra-include-dirs:
-- /home/jiasen/workspace/mxnet/build-1.6.0/include
+- /home/jiasen/workspace/mxnet/build-1.7.0/include
 extra-lib-dirs:
-- /home/jiasen/workspace/mxnet/build-1.6.0
+- /home/jiasen/workspace/mxnet/build-1.7.0
 flags:
   fei-base:
-    mxnet_geq_10600: true
+    mxnet_geq_10700: true
   fei-nn:
-    mxnet_geq_10600: true
+    mxnet_geq_10700: true
   fei-einops:
     mxnet: true


### PR DESCRIPTION
For example:
- `rearrange t "h w c -> c h w" []` will transpose the tensor from HWC to CHW.
- `rearrange t "b n c -> b (n c) []"` will reshape the tensor by merging up the last 2 axes.
- `rearrange t "(b n) c -> b n c" [#b .== 2]` will reshape the tensor by decompose the 1st axis into 2, where the new axis `n` is calculated automatically.
- ...

In most cases, the tensor can be `SymbolHandle`, `NDArrayHandle`, `NDArray` for mxnet.