### PR TITLE
avoid AxisSplitM

### DIFF
--- a/src/Fei/Einops/MXNet.hs
+++ b/src/Fei/Einops/MXNet.hs
@@ -25,6 +25,7 @@ data ReshapeOp
   | AxisSplitM [Int] -- split into a list of known axes: (n, m, l, ..)
   | AxisSplitU [Int] [Int] -- split into at most one unknown axis
   | AxisMerge -- merge 2 axes: (-3,)
+  deriving (Show)
 
 termsToOps :: ReshapeDirection -> HashMap Axis Int -> [Term Axis] -> Maybe [ReshapeOp]
 termsToOps dir knowns terms = mapM each terms
@@ -42,6 +43,7 @@ termsToOps dir knowns terms = mapM each terms
              in case () of
                   _ | num > 2 ->
                       case seg of
+                         -- TODO AxisSplitM is likely wrong when the ellipse is not at the end
                          [js] -> pure $ AxisSplitM (chopJust js)
                          [[Nothing], js] -> pure $ AxisSplitU [] (chopJust js)
                          [js, [Nothing]] -> pure $ AxisSplitU (chopJust js) []
@@ -51,7 +53,8 @@ termsToOps dir knowns terms = mapM each terms
                         case vs of
                           [Nothing, Just v] -> pure $ AxisSplitR v
                           [Just v, Nothing] -> pure $ AxisSplitL v
-                          [Just u, Just v]  -> pure $ AxisSplitM [u, v]
+                          [Just u, Just v]  -> -- cannot use AxisSplitM if not at the end
+                                               pure $ AxisSplitL u
                           _                 -> Nothing
                   _ -> Nothing
 

--- a/src/Fei/Einops/Operation.hs
+++ b/src/Fei/Einops/Operation.hs
@@ -13,7 +13,7 @@ import qualified RIO.Text              as T
 
 import           Fei.Einops.Expression
 
-data ReshapeDirection = ReshapeExpand | ReshapeReduce
+data ReshapeDirection = ReshapeExpand | ReshapeReduce deriving (Show)
 
 data RearrangeError = RearrangeError CallStack ExprError
 
@@ -52,7 +52,7 @@ rearrange tensor expr dims =
             -- the backend. So we resort everything to the backend side.
             Nothing -> do
                 tensor <- tensorReshapeSym ReshapeExpand left dims tensor
-                tensor <- tensorTranpose mapping   tensor
+                tensor <- tensorTranpose mapping tensor
                 tensor <- tensorReshapeSym ReshapeReduce right dims tensor
                 return tensor
             -- we have the shape of tensor, and we can solve the equation


### PR DESCRIPTION
Avoid using AxisSplitM when not at the end.

`"(b w) h => b w h"  b.==2 w.== 2` would fail, because it translates to `reshape (2, 2, 0)`, where mxnet complains `0` is referring to a unknown axis.